### PR TITLE
publish component descriptor to development repository

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -23,3 +23,7 @@ cp ${BASE_DEFINITION_PATH} "${CA_PATH}/component-descriptor.yaml"
 component-cli ca "${CA_PATH}" "${CTF_PATH}" \
     -r  ${RESOURCES_FILE_PATH} \
     VERSION=${EFFECTIVE_VERSION}
+
+
+# also upload the components to a open source repo
+component-cli ctf push --repo-ctx="eu.gcr.io/gardener-project/development" "${CTF_PATH}"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:

Publish the virtual-garden component descriptor to the public development OCI repository `eu.gcr.io/gardener-project/development` so it can used with other components in a development context. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Publish virtual-garden component to public OCI repository eu.gcr.io/gardener-project/development.
```
